### PR TITLE
Task2

### DIFF
--- a/user/sh.c
+++ b/user/sh.c
@@ -76,6 +76,11 @@ runcmd(struct cmd *cmd)
     ecmd = (struct execcmd*)cmd;
     if(ecmd->argv[0] == 0)
       exit(1);
+
+    if (ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0) { 
+        // TODO implementation 
+        exit(0); // required  
+        } 
     exec(ecmd->argv[0], ecmd->argv);
     fprintf(2, "exec %s failed\n", ecmd->argv[0]);
     break;

--- a/user/sh.c
+++ b/user/sh.c
@@ -72,18 +72,49 @@ runcmd(struct cmd *cmd)
   default:
     panic("runcmd");
 
-  case EXEC:
-    ecmd = (struct execcmd*)cmd;
-    if(ecmd->argv[0] == 0)
-      exit(1);
+ case EXEC:
+  ecmd = (struct execcmd*)cmd;
+  if(ecmd->argv[0] == 0)
+    exit(1);
 
-    if (ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0) { 
-        // TODO implementation 
-        exit(0); // required  
-        } 
-    exec(ecmd->argv[0], ecmd->argv);
-    fprintf(2, "exec %s failed\n", ecmd->argv[0]);
-    break;
+  /* ---------- custom built‑in: "!" ---------- */
+  if(ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0){
+    /* Join the rest of the arguments into one buffer */
+    char buf[1024] = {0};
+    int  len = 0;
+    for(int i = 1; ecmd->argv[i] && len < (int)sizeof(buf)-1; i++){
+      if(i != 1) buf[len++] = ' ';                  // keep spaces
+      int l = strlen(ecmd->argv[i]);
+      if(len + l >= (int)sizeof(buf)-1) l = sizeof(buf)-1-len;
+      memmove(buf + len, ecmd->argv[i], l);
+      len += l;
+    }
+    buf[len] = 0;
+
+    /* Rule 2: length guard */
+    if(len > 512){
+      printf("Message too long\n");
+      exit(0);
+    }
+
+    /* Rule 1: print, colouring every “os” blue */
+    for(int i = 0; i < len; i++){
+      if(i+1 < len && buf[i] == 'o' && buf[i+1] == 's'){
+        printf("\033[34m" "os" "\033[0m");   // blue “os”
+        i++;                                  // skip the ’s’ we just printed
+      } else {
+        printf("%c", buf[i]);
+      }
+    }
+    printf("\n");
+    exit(0);
+  }
+  /* ---------- end custom built‑in ---------- */
+
+  exec(ecmd->argv[0], ecmd->argv);
+  fprintf(2, "exec %s failed\n", ecmd->argv[0]);
+  break;
+
 
   case REDIR:
     rcmd = (struct redircmd*)cmd;

--- a/user/sh.c
+++ b/user/sh.c
@@ -78,37 +78,39 @@ runcmd(struct cmd *cmd)
     exit(1);
 
   /* ---------- custom built‑in: "!" ---------- */
-  if(ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0){
-    /* Join the rest of the arguments into one buffer */
-    char buf[1024] = {0};
-    int  len = 0;
-    for(int i = 1; ecmd->argv[i] && len < (int)sizeof(buf)-1; i++){
-      if(i != 1) buf[len++] = ' ';                  // keep spaces
-      int l = strlen(ecmd->argv[i]);
-      if(len + l >= (int)sizeof(buf)-1) l = sizeof(buf)-1-len;
-      memmove(buf + len, ecmd->argv[i], l);
-      len += l;
-    }
-    buf[len] = 0;
+  /* ---------- custom built‑in: "!" ---------- */
+if(ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0){
+  char buf[1024] = {0};
+  int  len = 0;
+  for(int i = 1; ecmd->argv[i] && len < (int)sizeof(buf)-1; i++){
+    if(i != 1) buf[len++] = ' ';
+    int l = strlen(ecmd->argv[i]);
+    if(len + l >= (int)sizeof(buf)-1) l = sizeof(buf)-1-len;
+    memmove(buf + len, ecmd->argv[i], l);
+    len += l;
+  }
+  buf[len] = 0;
 
-    /* Rule 2: length guard */
-    if(len > 512){
-      printf("Message too long\n");
-      exit(0);
-    }
-
-    /* Rule 1: print, colouring every “os” blue */
-    for(int i = 0; i < len; i++){
-      if(i+1 < len && buf[i] == 'o' && buf[i+1] == 's'){
-        printf("\033[34m" "os" "\033[0m");   // blue “os”
-        i++;                                  // skip the ’s’ we just printed
-      } else {
-        printf("%c", buf[i]);
-      }
-    }
-    printf("\n");
+  if(len > 512){
+    printf("Message too long\n");
     exit(0);
   }
+
+  /* colour every “os” blue */
+  for(int i = 0; i < len; i++){
+    if(i+1 < len && buf[i] == 'o' && buf[i+1] == 's'){
+      const char *blue = "\033[34mos\033[0m";
+      write(1, blue, strlen(blue));
+      i++;                     // skip the 's'
+    } else {
+      write(1, &buf[i], 1);    // single byte
+    }
+  }
+  write(1, "\n", 1);
+  exit(0);
+}
+/* ---------- end custom built‑in ---------- */
+
   /* ---------- end custom built‑in ---------- */
 
   exec(ecmd->argv[0], ecmd->argv);

--- a/user/sh.c
+++ b/user/sh.c
@@ -77,8 +77,7 @@ runcmd(struct cmd *cmd)
   if(ecmd->argv[0] == 0)
     exit(1);
 
-  /* ---------- custom built‑in: "!" ---------- */
-  /* ---------- custom built‑in: "!" ---------- */
+ 
 if(ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0){
   char buf[1024] = {0};
   int  len = 0;
@@ -96,7 +95,7 @@ if(ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0){
     exit(0);
   }
 
-  /* colour every “os” blue */
+
   for(int i = 0; i < len; i++){
     if(i+1 < len && buf[i] == 'o' && buf[i+1] == 's'){
       const char *blue = "\033[34mos\033[0m";
@@ -109,9 +108,7 @@ if(ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0){
   write(1, "\n", 1);
   exit(0);
 }
-/* ---------- end custom built‑in ---------- */
 
-  /* ---------- end custom built‑in ---------- */
 
   exec(ecmd->argv[0], ecmd->argv);
   fprintf(2, "exec %s failed\n", ecmd->argv[0]);


### PR DESCRIPTION
! built‑in – lets users echo custom text directly from the shell without forking an external program.

Each occurrence of os is printed in blue .

If the joined text is > 512 bytes, the shell aborts the print and writes "Message too long".

Portable output – replaced printf("%c", …) with raw write(1, …) calls because xv6’s user‑space printf lacks %c support.